### PR TITLE
fix: Include email read permission in GitHub App

### DIFF
--- a/integrations/create_github_app.py
+++ b/integrations/create_github_app.py
@@ -98,6 +98,7 @@ GH_APP_PARAMS = {
     "single_file_name": ".deepsource.toml",
     "members": "read",
     "organization_hooks": "read",
+    "emails": "read",
     "public": True,
 }
 


### PR DESCRIPTION
Include `email` `read` permission when creating the GitHub App. The permission is required to perform OAuth with GitHub.